### PR TITLE
waf changes to send upstream before upgrade to waf2 -- merge into waf-2.0.7-patched

### DIFF
--- a/waflib/Tools/qt5.py
+++ b/waflib/Tools/qt5.py
@@ -477,6 +477,9 @@ def configure(self):
 	if 'COMPILER_CXX' not in self.env:
 		self.fatal('No CXX compiler defined: did you forget to configure compiler_cxx first?')
 
+	if self.env.NO_QT5_DETECT:
+		return
+
 	# Qt5 may be compiled with '-reduce-relocations' which requires dependent programs to have -fPIE or -fPIC?
 	frag = '#include <QApplication>\nint main(int argc, char **argv) {return 0;}\n'
 	uses = 'QT5CORE QT5WIDGETS QT5GUI'


### PR DESCRIPTION
Qt parses each argument line-by-line. Avoiding the quoting and escaping
from Task.quote_flag saves us from "too many files specified" moc/rcc error.