### PR TITLE
detect if node is $SCHRODINGER_SRC/mmshare

### DIFF
--- a/waflib/Node.py
+++ b/waflib/Node.py
@@ -771,19 +771,24 @@ class Node(object):
 		# <bld_dir>/__root__/abspath/to/file to avoid contamination of
 		# filesystem.
 		schrodinger_path = os.path.realpath(os.environ['SCHRODINGER'])
+		# $SCHRODINGER_SRC
 		schrodinger_src_path = os.path.realpath(os.environ['SCHRODINGER_SRC'])
+		# e.g. $SCHRODINGER_SRC/mmshare
+		top_path = os.path.realpath(self.ctx.srcnode.abspath())
 		self_path = os.path.realpath(self.abspath())
 
 		if sys.platform == 'win32':
 			# Windows file paths are case insensitive, lowercase before comparing
 			schrodinger_path = schrodinger_path.lower()
 			schrodinger_src_path = schrodinger_src_path.lower()
+			top_path = top_path.lower()
 			self_path = self_path.lower()
 
 		if self_path.startswith(schrodinger_path):
 			return self
-
-		if self_path.startswith(schrodinger_src_path):
+		elif self_path.startswith(top_path):
+			return self.ctx.bldnode.make_node(self_path[len(top_path)+1:])
+		elif self_path.startswith(schrodinger_src_path):
 			return self.ctx.bldnode.make_node(self_path[len(schrodinger_src_path)+1:])
 
 		# the file is external to the current project, make a fake root in the current build directory


### PR DESCRIPTION
Without this, the nodes get created in $SCHRODINGER/mmshare-vx.y/mmshare/include rather than $SCHRODINGER/mmshare-vx.y/include 