### PR TITLE
BLDMGR-10051: Waf 2.1.6 patched

### DIFF
--- a/waflib/Node.py
+++ b/waflib/Node.py
@@ -807,19 +807,24 @@ class Node(object):
 		# <bld_dir>/__root__/abspath/to/file to avoid contamination of
 		# filesystem.
 		schrodinger_path = os.path.realpath(os.environ['SCHRODINGER'])
+		# $SCHRODINGER_SRC
 		schrodinger_src_path = os.path.realpath(os.environ['SCHRODINGER_SRC'])
+		# e.g. $SCHRODINGER_SRC/mmshare
+		top_path = os.path.realpath(self.ctx.srcnode.abspath())
 		self_path = os.path.realpath(self.abspath())
 
 		if sys.platform == 'win32':
 			# Windows file paths are case insensitive, lowercase before comparing
 			schrodinger_path = schrodinger_path.lower()
 			schrodinger_src_path = schrodinger_src_path.lower()
+			top_path = top_path.lower()
 			self_path = self_path.lower()
 
 		if self_path.startswith(schrodinger_path):
 			return self
-
-		if self_path.startswith(schrodinger_src_path):
+		elif self_path.startswith(top_path):
+			return self.ctx.bldnode.make_node(self_path[len(top_path)+1:])
+		elif self_path.startswith(schrodinger_src_path):
 			return self.ctx.bldnode.make_node(self_path[len(schrodinger_src_path)+1:])
 
 		# the file is external to the current project, make a fake root in the current build directory

--- a/waflib/Node.py
+++ b/waflib/Node.py
@@ -800,6 +800,14 @@ class Node(object):
 				return self.ctx.bldnode.make_node(lst)
 			lst.append(cur.name)
 			cur = cur.parent
+		# Allow creation of nodes in $SCHRODINGER, even if not under build
+		# directory (e.g. $SCHRODINGER/internal/bin/foo.exe), if we try to
+		# create a file that is outside $SCHRODINGER, it will create in
+		# <bld_dir>/__root__/abspath/to/file to avoid contamination of
+		# filesystem.
+		schrodinger_node = find_schrodinger_node(self.ctx)
+		if self.is_child_of(schrodinger_node):
+			return self
 		# the file is external to the current project, make a fake root in the current build directory
 		lst.reverse()
 		if lst and Utils.is_win32 and len(lst[0]) == 2 and lst[0].endswith(':'):
@@ -958,6 +966,18 @@ class Node(object):
 					return ret
 				raise
 		return ret
+
+
+def find_schrodinger_node(bld):
+	"""Locate $SCHRODINGER in a relative path"""
+	schrodinger_node = bld.bldnode
+	absolute_schrodinger = os.path.realpath(os.environ['SCHRODINGER'])
+	while schrodinger_node:
+		if os.path.realpath(schrodinger_node.abspath()) == absolute_schrodinger:
+			break
+		schrodinger_node = schrodinger_node.parent
+	return schrodinger_node
+
 
 pickle_lock = Utils.threading.Lock()
 """Lock mandatory for thread-safe node serialization"""

--- a/waflib/Node.py
+++ b/waflib/Node.py
@@ -807,15 +807,20 @@ class Node(object):
 		# <bld_dir>/__root__/abspath/to/file to avoid contamination of
 		# filesystem.
 		schrodinger_path = os.path.realpath(os.environ['SCHRODINGER'])
+		schrodinger_src_path = os.path.realpath(os.environ['SCHRODINGER_SRC'])
 		self_path = os.path.realpath(self.abspath())
 
 		if sys.platform == 'win32':
 			# Windows file paths are case insensitive, lowercase before comparing
 			schrodinger_path = schrodinger_path.lower()
+			schrodinger_src_path = schrodinger_src_path.lower()
 			self_path = self_path.lower()
 
 		if self_path.startswith(schrodinger_path):
 			return self
+
+		if self_path.startswith(schrodinger_src_path):
+			return self.ctx.bldnode.make_node(self_path[len(schrodinger_src_path)+1:])
 
 		# the file is external to the current project, make a fake root in the current build directory
 		lst.reverse()

--- a/waflib/Node.py
+++ b/waflib/Node.py
@@ -800,14 +800,23 @@ class Node(object):
 				return self.ctx.bldnode.make_node(lst)
 			lst.append(cur.name)
 			cur = cur.parent
+
 		# Allow creation of nodes in $SCHRODINGER, even if not under build
 		# directory (e.g. $SCHRODINGER/internal/bin/foo.exe), if we try to
 		# create a file that is outside $SCHRODINGER, it will create in
 		# <bld_dir>/__root__/abspath/to/file to avoid contamination of
 		# filesystem.
-		schrodinger_node = find_schrodinger_node(self.ctx)
-		if self.is_child_of(schrodinger_node):
+		schrodinger_path = os.path.realpath(os.environ['SCHRODINGER'])
+		self_path = os.path.realpath(self.abspath())
+
+		if sys.platform == 'win32':
+			# Windows file paths are case insensitive, lowercase before comparing
+			schrodinger_path = schrodinger_path.lower()
+			self_path = self_path.lower()
+
+		if self_path.startswith(schrodinger_path):
 			return self
+
 		# the file is external to the current project, make a fake root in the current build directory
 		lst.reverse()
 		if lst and Utils.is_win32 and len(lst[0]) == 2 and lst[0].endswith(':'):

--- a/waflib/Tools/c.py
+++ b/waflib/Tools/c.py
@@ -6,7 +6,7 @@
 
 from waflib import TaskGen, Task
 from waflib.Tools import c_preproc
-from waflib.Tools.ccroot import link_task, stlink_task
+from waflib.Tools.ccroot import link_task, pdb_flag, stlink_task
 
 @TaskGen.extension('.c')
 def c_hook(self, node):
@@ -17,10 +17,12 @@ def c_hook(self, node):
 
 class c(Task.Task):
 	"Compiles C files into object files"
-	run_str = '${CC} ${ARCH_ST:ARCH} ${CFLAGS} ${FRAMEWORKPATH_ST:FRAMEWORKPATH} ${CPPPATH_ST:INCPATHS} ${DEFINES_ST:DEFINES} ${CC_SRC_F}${SRC} ${CC_TGT_F}${TGT[0].abspath()} ${CPPFLAGS}'
+	run_str = '${CC} ${ARCH_ST:ARCH} ${CFLAGS} ${tsk.pdb_flag()} ${FRAMEWORKPATH_ST:FRAMEWORKPATH} ${CPPPATH_ST:INCPATHS} ${DEFINES_ST:DEFINES} ${CC_SRC_F}${SRC} ${CC_TGT_F}${TGT[0].abspath()} ${CPPFLAGS}'
 	vars    = ['CCDEPS'] # unused variable to depend on, just in case
 	ext_in  = ['.h'] # set the build order easily by using ext_out=['.h']
 	scan    = c_preproc.scan
+
+	pdb_flag = pdb_flag
 
 class cprogram(link_task):
 	"Links object files into c programs"
@@ -36,4 +38,3 @@ class cshlib(cprogram):
 class cstlib(stlink_task):
 	"Links object files into a c static libraries"
 	pass # do not remove
-

--- a/waflib/Tools/c_preproc.py
+++ b/waflib/Tools/c_preproc.py
@@ -26,7 +26,7 @@ A dumb preprocessor is also available in the tool *c_dumbpreproc*
 """
 # TODO: more varargs, pragma once
 
-import re, string, traceback
+import os, re, string, traceback
 from waflib import Logs, Utils, Errors
 
 class PreprocError(Errors.WafError):
@@ -1081,11 +1081,19 @@ def scan(task):
 	except AttributeError:
 		raise Errors.WafError('%r is missing a feature such as "c", "cxx" or "includes": ' % task.generator)
 
-	if go_absolute:
-		nodepaths = incn + [task.generator.bld.root.find_dir(x) for x in standard_includes]
-	else:
-		nodepaths = [x for x in incn if x.is_child_of(x.ctx.srcnode) or x.is_child_of(x.ctx.bldnode)]
+	nodepaths= get_header_nodepaths(incn)
 
 	tmp = c_parser(nodepaths)
 	tmp.start(task.inputs[0], task.env)
 	return (tmp.nodes, tmp.names)
+
+def get_header_nodepaths(includes):
+	# We want to find any includes that start with SCHRODINGER or
+	# SCHRODINGER_SRC since we care about header files even though the src and
+	# bld nodes may be subdirs thereof. The best example is
+	# $SCHRODINGER/$MMSHARE/include directory, and a build node might be
+	# $SCHRODINGER/$MMSHARE/canvaslibs
+	schrodinger = os.path.abspath(os.environ['SCHRODINGER'])
+	schrodinger_src = os.path.abspath(os.environ['SCHRODINGER_SRC'])
+	nodepaths=[x for x in includes if os.path.abspath(x.abspath()).startswith(schrodinger) or os.path.abspath(x.abspath()).startswith(schrodinger_src)]
+	return nodepaths

--- a/waflib/Tools/c_preproc.py
+++ b/waflib/Tools/c_preproc.py
@@ -1093,7 +1093,17 @@ def get_header_nodepaths(includes):
 	# bld nodes may be subdirs thereof. The best example is
 	# $SCHRODINGER/$MMSHARE/include directory, and a build node might be
 	# $SCHRODINGER/$MMSHARE/canvaslibs
+	#
+	# NOTE: After enabling Package Factory builds, all thirdparty libs will be
+	# located in the $SCHRODINGER directory, so we should explicitly exclude them
+
 	schrodinger = os.path.abspath(os.environ['SCHRODINGER'])
 	schrodinger_src = os.path.abspath(os.environ['SCHRODINGER_SRC'])
-	nodepaths=[x for x in includes if os.path.abspath(x.abspath()).startswith(schrodinger) or os.path.abspath(x.abspath()).startswith(schrodinger_src)]
+	schrodinger_lib = os.path.abspath(os.environ['SCHRODINGER_LIB']) # PF directory
+
+	def _is_selected_inc_path(inc_path):
+		inc_path = os.path.abspath(x.abspath())
+		return (inc_path.startswith(schrodinger) or inc_path.startswith(schrodinger_src)) and not inc_path.startswith(schrodinger_lib)
+
+	nodepaths=[x for x in includes if _is_selected_inc_path(x)]
 	return nodepaths

--- a/waflib/Tools/c_preproc.py
+++ b/waflib/Tools/c_preproc.py
@@ -1102,7 +1102,7 @@ def get_header_nodepaths(includes):
 	schrodinger_lib = os.path.abspath(os.environ['SCHRODINGER_LIB']) # PF directory
 
 	def _is_selected_inc_path(inc_path):
-		inc_path = os.path.abspath(x.abspath())
+		inc_path = os.path.abspath(inc_path.abspath())
 		return (inc_path.startswith(schrodinger) or inc_path.startswith(schrodinger_src)) and not inc_path.startswith(schrodinger_lib)
 
 	nodepaths=[x for x in includes if _is_selected_inc_path(x)]

--- a/waflib/Tools/c_preproc.py
+++ b/waflib/Tools/c_preproc.py
@@ -1103,7 +1103,7 @@ def get_header_nodepaths(includes):
 
 	def _is_selected_inc_path(inc_path):
 		inc_path = os.path.abspath(inc_path.abspath())
-		return (inc_path.startswith(schrodinger) or inc_path.startswith(schrodinger_src)) and not inc_path.startswith(schrodinger_lib)
+		return inc_path.startswith((schrodinger, schrodinger_src)) and not inc_path.startswith(schrodinger_lib)
 
 	nodepaths=[x for x in includes if _is_selected_inc_path(x)]
 	return nodepaths

--- a/waflib/Tools/ccroot.py
+++ b/waflib/Tools/ccroot.py
@@ -822,3 +822,18 @@ def set_full_paths_hpux(self):
 			else:
 				lst.append(os.path.normpath(os.path.join(base, x)))
 		self.env[var] = lst
+
+def pdb_flag(self):
+	"""
+	Returns a string representing a unique, per-object file path to a .pdb file
+	(by default, /Zi would use a shared .pdb requiring synchronization)
+	"""
+	zi_flag = '/Zi'
+	env_vars = ('CFLAGS', 'CXXFLAGS')
+	if not any([zi_flag in self.env[env_var] for env_var in env_vars]):
+		return ''
+	schrodinger = Node.find_schrodinger_node(self.generator.bld)
+	mapfiles = schrodinger.find_or_declare('mapfiles')
+	pdb = mapfiles.find_or_declare(self.outputs[0].path_from(schrodinger))
+	pdb = pdb.change_ext('.pdb')
+	return '/Fd'+pdb.abspath()

--- a/waflib/Tools/ccroot.py
+++ b/waflib/Tools/ccroot.py
@@ -534,7 +534,7 @@ def apply_implib(self):
 	else:
 		name = os.path.split(self.target)[1]
 	implib = self.env.implib_PATTERN % name
-	implib = dll.parent.find_or_declare(implib)
+	implib = get_implib_directory(dll).find_or_declare(implib)
 	self.env.append_value('LINKFLAGS', self.env.IMPLIB_ST % implib.bldpath())
 	self.link_task.outputs.append(implib)
 
@@ -566,6 +566,26 @@ def apply_implib(self):
 					self.env.IMPLIBDIR = self.env.LIBDIR
 		self.implib_install_task = self.add_install_files(install_to=inst_to, install_from=implib,
 			chmod=self.link_task.chmod, task=self.link_task)
+
+def get_implib_directory(dll):
+	"""
+	Generate the implib directory node based on the DLL node.
+
+	If the DLL is in Windows-x64/, place the implib in ../../lib/Windows-x64/.
+	If the DLL is in internal/bin/, place the implib in ../lib/.
+	Otherwise, place the implib in the same directory as the DLL.
+
+	:param waflib.Node dll: Node representing the DLL.
+	:rtype waflib.Node:
+	:return: Node representing the directory where the implib should be placed.
+	"""
+	dll_dir = dll.parent
+	if dll_dir.suffix() == 'Windows-x64':
+		return dll_dir.parent.parent.find_or_declare('lib').find_or_declare('Windows-x64')
+	elif dll_dir.suffix() == 'bin' and dll_dir.parent.suffix() == 'internal':
+		return dll_dir.parent.find_or_declare('lib')
+	else:
+		return dll_dir
 
 # ============ the code above must not know anything about vnum processing on unix platforms =========
 
@@ -802,4 +822,3 @@ def set_full_paths_hpux(self):
 			else:
 				lst.append(os.path.normpath(os.path.join(base, x)))
 		self.env[var] = lst
-

--- a/waflib/Tools/ccroot.py
+++ b/waflib/Tools/ccroot.py
@@ -580,9 +580,9 @@ def get_implib_directory(dll):
 	:return: Node representing the directory where the implib should be placed.
 	"""
 	dll_dir = dll.parent
-	if dll_dir.suffix() == 'Windows-x64':
+	if dll_dir.parent.suffix() == 'bin' and dll_dir.suffix() == 'Windows-x64':
 		return dll_dir.parent.parent.find_or_declare('lib').find_or_declare('Windows-x64')
-	elif dll_dir.suffix() == 'bin' and dll_dir.parent.suffix() == 'internal':
+	elif dll_dir.parent.suffix() == 'internal' and dll_dir.suffix() == 'bin':
 		return dll_dir.parent.find_or_declare('lib')
 	else:
 		return dll_dir

--- a/waflib/Tools/cxx.py
+++ b/waflib/Tools/cxx.py
@@ -4,9 +4,9 @@
 
 "Base for c++ programs and libraries"
 
-from waflib import TaskGen, Task
+from waflib import Node, TaskGen, Task
 from waflib.Tools import c_preproc
-from waflib.Tools.ccroot import link_task, stlink_task
+from waflib.Tools.ccroot import link_task, pdb_flag, stlink_task
 
 @TaskGen.extension('.cpp','.cc','.cxx','.C','.c++')
 def cxx_hook(self, node):
@@ -18,10 +18,13 @@ if not '.c' in TaskGen.task_gen.mappings:
 
 class cxx(Task.Task):
 	"Compiles C++ files into object files"
-	run_str = '${CXX} ${ARCH_ST:ARCH} ${CXXFLAGS} ${FRAMEWORKPATH_ST:FRAMEWORKPATH} ${CPPPATH_ST:INCPATHS} ${DEFINES_ST:DEFINES} ${CXX_SRC_F}${SRC} ${CXX_TGT_F}${TGT[0].abspath()} ${CPPFLAGS}'
+	run_str = '${CXX} ${ARCH_ST:ARCH} ${CXXFLAGS} ${tsk.pdb_flag()} ${FRAMEWORKPATH_ST:FRAMEWORKPATH} ${CPPPATH_ST:INCPATHS} ${DEFINES_ST:DEFINES} ${CXX_SRC_F}${SRC} ${CXX_TGT_F}${TGT[0].abspath()} ${CPPFLAGS}'
 	vars    = ['CXXDEPS'] # unused variable to depend on, just in case
 	ext_in  = ['.h'] # set the build order easily by using ext_out=['.h']
 	scan    = c_preproc.scan
+
+	pdb_flag = pdb_flag
+
 
 class cxxprogram(link_task):
 	"Links object files into c++ programs"
@@ -37,4 +40,3 @@ class cxxshlib(cxxprogram):
 class cxxstlib(stlink_task):
 	"Links object files into c++ static libraries"
 	pass # do not remove
-

--- a/waflib/Tools/fc.py
+++ b/waflib/Tools/fc.py
@@ -47,6 +47,10 @@ def modfile(conf, name):
 		'UPPER.mod' :modname.upper() + suffix.lower(),
 		'UPPER'     :modname.upper() + suffix.upper()}[conf.env.FC_MOD_CAPITALIZATION or 'lower']
 
+@conf
+def is_fortran_mod(conf, node):
+	return str(node).lower().endswith('.mod')
+
 def get_fortran_tasks(tsk):
 	"""
 	Obtains all fortran tasks from the same build group. Those tasks must not have
@@ -142,7 +146,7 @@ class fc(Task.Task):
 				# ourselves as task.dep_nodes (additional input nodes)
 				tmp = []
 				for t in outs[k]:
-					tmp.extend(t.outputs)
+					tmp.extend(f for f in t.outputs if bld.is_fortran_mod(f))
 				a.dep_nodes.extend(tmp)
 				a.dep_nodes.sort(key=lambda x: x.abspath())
 

--- a/waflib/Tools/fc.py
+++ b/waflib/Tools/fc.py
@@ -7,6 +7,7 @@
 Fortran support
 """
 
+import os, re
 from waflib import Utils, Task, Errors
 from waflib.Tools import ccroot, fc_config, fc_scan
 from waflib.TaskGen import extension
@@ -61,6 +62,24 @@ def get_fortran_tasks(tsk):
 	bld = tsk.generator.bld
 	tasks = bld.get_tasks_group(bld.get_group_idx(tsk.generator))
 	return [x for x in tasks if isinstance(x, fc) and not getattr(x, 'nomod', None) and not getattr(x, 'mod_fortran_done', None)]
+
+@conf
+def moddir(conf, tsk):
+	"""
+	For a given task, return the the name of the module directory as given
+	in the module_dir inputs for that task as a string. Note that the
+	module directory should be provided as an absolute path.
+	"""
+	try:
+		module_dir=tsk.generator.module_dir
+	except:
+		module_dir = None
+	if module_dir is not None:
+		if not os.path.isdir(module_dir):
+			os.makedirs(module_dir)
+		return os.path.relpath(module_dir, conf.env.PREFIX)
+	return ""
+
 
 class fc(Task.Task):
 	"""
@@ -118,8 +137,10 @@ class fc(Task.Task):
 			key = tsk.uid()
 			for x in bld.raw_deps[key]:
 				if x.startswith('MOD@'):
-					name = bld.modfile(x.replace('MOD@', ''))
-					node = bld.srcnode.find_or_declare(name)
+					name=os.path.join(
+                                            bld.moddir(tsk),
+                                            bld.modfile(x.replace('MOD@','')))
+					node=bld.srcnode.find_or_declare(name)
 					tsk.set_outputs(node)
 					outs[node].add(tsk)
 
@@ -128,8 +149,10 @@ class fc(Task.Task):
 			key = tsk.uid()
 			for x in bld.raw_deps[key]:
 				if x.startswith('USE@'):
-					name = bld.modfile(x.replace('USE@', ''))
-					node = bld.srcnode.find_resource(name)
+					name=os.path.join(
+                                            bld.moddir(tsk),
+                                            bld.modfile(x.replace('USE@','')))
+					node=bld.srcnode.find_resource(name)
 					if node and node not in tsk.outputs:
 						if not node in bld.node_deps[key]:
 							bld.node_deps[key].append(node)

--- a/waflib/Tools/fc_scan.py
+++ b/waflib/Tools/fc_scan.py
@@ -3,17 +3,24 @@
 # DC 2008
 # Thomas Nagy 2016-2018 (ita)
 
+from collections import namedtuple
 import re
+
+from waflib import Utils
 
 INC_REGEX = r"""(?:^|['">]\s*;)\s*(?:|#\s*)INCLUDE\s+(?:\w+_)?[<"'](.+?)(?=["'>])"""
 USE_REGEX = r"""(?:^|;)\s*USE(?:\s+|(?:(?:\s*,\s*(?:NON_)?INTRINSIC)?\s*::))\s*(\w+)"""
 MOD_REGEX = r"""(?:^|;)\s*MODULE(?!\s+(?:PROCEDURE|SUBROUTINE|FUNCTION))\s+(\w+)"""
 SMD_REGEX = r"""(?:^|;)\s*SUBMODULE\s*\(([\w:]+)\)\s*(\w+)"""
 
-re_inc = re.compile(INC_REGEX, re.I)
-re_use = re.compile(USE_REGEX, re.I)
-re_mod = re.compile(MOD_REGEX, re.I)
-re_smd = re.compile(SMD_REGEX, re.I)
+re_inc = re.compile(INC_REGEX, re.I|re.M)
+re_use = re.compile(USE_REGEX, re.I|re.M)
+re_mod = re.compile(MOD_REGEX, re.I|re.M)
+re_smd = re.compile(SMD_REGEX, re.I|re.M)
+
+DEPS_CACHE_SIZE = 100000
+
+Deps = namedtuple('Deps', ['incs', 'uses', 'mods'])
 
 class fortran_parser(object):
 	"""
@@ -24,7 +31,7 @@ class fortran_parser(object):
 	* the module names used by the fortran files
 	"""
 	def __init__(self, incpaths):
-		self.seen = []
+		self.seen = set()
 		"""Files already parsed"""
 
 		self.nodes = []
@@ -45,26 +52,22 @@ class fortran_parser(object):
 		:return: lists representing the includes, the modules used, and the modules created by a fortran file
 		:rtype: tuple of list of strings
 		"""
-		txt = node.read()
-		incs = []
-		uses = []
-		mods = []
-		for line in txt.splitlines():
-			# line by line regexp search? optimize?
-			m = re_inc.search(line)
-			if m:
-				incs.append(m.group(1))
-			m = re_use.search(line)
-			if m:
-				uses.append(m.group(1))
-			m = re_mod.search(line)
-			if m:
-				mods.append(m.group(1))
-			m = re_smd.search(line)
-			if m:
-				uses.append(m.group(1))
-				mods.append('{0}:{1}'.format(m.group(1),m.group(2)))
-		return (incs, uses, mods)
+		try:
+			cache = node.ctx.cache_fc_scan_deps
+		except AttributeError:
+			cache = node.ctx.cache_fc_scan_deps = Utils.lru_cache(DEPS_CACHE_SIZE)
+		try:
+			return cache[node]
+		except KeyError:
+			txt = node.read()
+			smds = re_smd.findall(txt)
+			deps = Deps(
+				incs=re_inc.findall(txt),
+				uses=re_use.findall(txt) + [smd[0] for smd in smds],
+				mods=re_mod.findall(txt) + [':'.join(smd) for smd in smds],
+			)
+			cache[node] = deps
+			return deps
 
 	def start(self, node):
 		"""
@@ -83,19 +86,19 @@ class fortran_parser(object):
 		Processes a single file during dependency parsing. Extracts files used
 		modules used and modules provided.
 		"""
-		incs, uses, mods = self.find_deps(node)
-		for x in incs:
-			if x in self.seen:
-				continue
-			self.seen.append(x)
+		if node in self.seen:
+			return
+		deps = self.find_deps(node)
+		self.seen.add(node)
+		for x in deps.incs:
 			self.tryfind_header(x)
 
-		for x in uses:
+		for x in deps.uses:
 			name = "USE@%s" % x
 			if not name in self.names:
 				self.names.append(name)
 
-		for x in mods:
+		for x in deps.mods:
 			name = "MOD@%s" % x
 			if not name in self.names:
 				self.names.append(name)

--- a/waflib/Tools/fc_scan.py
+++ b/waflib/Tools/fc_scan.py
@@ -19,6 +19,7 @@ re_mod = re.compile(MOD_REGEX, re.I|re.M)
 re_smd = re.compile(SMD_REGEX, re.I|re.M)
 
 DEPS_CACHE_SIZE = 100000
+FILE_CACHE_SIZE = 100000
 
 Deps = namedtuple('Deps', ['incs', 'uses', 'mods'])
 
@@ -91,6 +92,9 @@ class fortran_parser(object):
 		deps = self.find_deps(node)
 		self.seen.add(node)
 		for x in deps.incs:
+			if x in self.seen:
+				continue
+			self.seen.add(x)
 			self.tryfind_header(x)
 
 		for x in deps.uses:
@@ -112,7 +116,7 @@ class fortran_parser(object):
 		"""
 		found = None
 		for n in self.incpaths:
-			found = n.find_resource(filename)
+			found = self.cached_find_resource(n, filename)
 			if found:
 				self.nodes.append(found)
 				self.waiting.append(found)
@@ -121,3 +125,26 @@ class fortran_parser(object):
 			if not filename in self.names:
 				self.names.append(filename)
 
+	def cached_find_resource(self, node, filename):
+		"""
+		Find a file from the input directory
+
+		:param node: directory
+		:type node: :py:class:`waflib.Node.Node`
+		:param filename: header to find
+		:type filename: string
+		:return: the node if found, or None
+		:rtype: :py:class:`waflib.Node.Node`
+		"""
+		try:
+			cache = node.ctx.cache_fc_scan_node
+		except AttributeError:
+			cache = node.ctx.cache_fc_scan_node = Utils.lru_cache(FILE_CACHE_SIZE)
+
+		key = (node, filename)
+		try:
+			return cache[key]
+		except KeyError:
+			ret = node.find_resource(filename)
+			cache[key] = ret
+			return ret

--- a/waflib/Tools/qt5.py
+++ b/waflib/Tools/qt5.py
@@ -547,6 +547,9 @@ def configure(self):
 	if not has_xml:
 		Logs.error('No xml.sax support was found, rcc dependencies will be incomplete!')
 
+	if self.env.NO_QT5_DETECT:
+		return
+
 	feature = 'qt6' if self.want_qt6 else 'qt5'
 
 	# Qt6 requires C++17 (https://www.qt.io/blog/qt-6.0-released)

--- a/waflib/Tools/qt5.py
+++ b/waflib/Tools/qt5.py
@@ -247,20 +247,16 @@ class qxx(Task.classes['cxx']):
 			base2 = d[:-4]
 
 			# foo.moc from foo.cpp
-			prefix = node.name[:node.name.rfind('.')]
-			if base2 == prefix:
-				h_node = node
-			else:
-				# this deviates from the standard
-				# if bar.cpp includes foo.moc, then assume it is from foo.h
-				for x in include_nodes:
-					for e in MOC_H:
-						h_node = x.find_node(base2 + e)
-						if h_node:
-							break
-					else:
-						continue
-					break
+			# this deviates from the standard
+			# if bar.cpp includes foo.moc, then assume it is from foo.h
+			for x in include_nodes:
+				for e in MOC_H:
+					h_node = x.find_node(base2 + e)
+					if h_node:
+						break
+				else:
+					continue
+				break
 			if h_node:
 				m_node = h_node.change_ext('.moc')
 			else:

--- a/waflib/extras/parallel_debug.py
+++ b/waflib/extras/parallel_debug.py
@@ -285,7 +285,7 @@ def set_running(self, by, tsk):
 			i = cache[tsk]
 			del cache[tsk]
 
-		self.taskinfo.put( (i, id(tsk), time.time(), tsk.__class__.__name__, self.processed, self.count, by, ",".join(map(str, tsk.outputs)))  )
+		self.taskinfo.put( (i, id(tsk), time.time(), tsk.__class__.__name__, self.processed, self.count, by, str(tsk))  )
 Runner.Parallel.set_running = set_running
 
 def name2class(name):

--- a/waflib/extras/parallel_debug.py
+++ b/waflib/extras/parallel_debug.py
@@ -40,7 +40,7 @@ svg.addEventListener('mouseover', function(e) {
 	if (x) {
 		g.setAttribute('class', g.getAttribute('class') + ' over');
 		x.setAttribute('class', x.getAttribute('class') + ' over');
-		showInfo(e, g.id, e.target.attributes.tooltip.value);
+		showInfo(e, g.id, e.target.attributes.outputs.value, e.target.attributes.taskstr.value, e.target.attributes.time.value);
 	}
 }, false);
 
@@ -54,21 +54,35 @@ svg.addEventListener('mouseout', function(e) {
 		}
 }, false);
 
-function showInfo(evt, txt, details) {
+function showInfo(evt, cls, outputs, str, time) {
 ${if project.tooltip}
 	tooltip = document.getElementById('tooltip');
 
-	var t = document.getElementById('tooltiptext');
-	t.firstChild.data = txt + " " + details;
+	var tcls = document.getElementById('tooltipcls');
+	tcls.firstChild.data = "Task: " + cls;
+
+	var tstr = document.getElementById('tooltipstr');
+	tstr.firstChild.data = str;
+
+	var ttime = document.getElementById('tooltiptime');
+	ttime.firstChild.data = time + " s";
+
+	var toutputs = document.getElementById('tooltipoutputs');
+	toutputs.firstChild.data = "Outputs: " + outputs;
+
+	var textlength = Math.max(tcls.getComputedTextLength(), tstr.getComputedTextLength(), ttime.getComputedTextLength(), toutputs.getComputedTextLength())
+
+    var svgwidth = document.getElementById('svg602').attributes.width.value
 
 	var x = evt.clientX + 9;
-	if (x > 250) { x -= t.getComputedTextLength() + 16; }
+	if (x > (svgwidth - textlength)) { x -= textlength + 16; }
+	x = Math.max(x, 5);
 	var y = evt.clientY + 20;
 	tooltip.setAttribute("transform", "translate(" + x + "," + y + ")");
 	tooltip.setAttributeNS(null, "visibility", "visible");
 
 	var r = document.getElementById('tooltiprect');
-	r.setAttribute('width', t.getComputedTextLength() + 6);
+	r.setAttribute('width', textlength + 6);
 ${endif}
 }
 
@@ -92,7 +106,7 @@ ${endif}
 ${for cls in project.groups}
   <g id='${cls.classname}'>
     ${for rect in cls.rects}
-    <rect x='${rect.x}' y='${rect.y}' width='${rect.width}' height='${rect.height}' tooltip='${rect.name}' style="font-size:10;fill:${rect.color};fill-rule:evenodd;stroke:#000000;stroke-width:0.4;" />
+    <rect x='${rect.x}' y='${rect.y}' width='${rect.width}' height='${rect.height}' outputs='${rect.outputs}' taskstr='${rect.taskstr}' time='${rect.time}' style="font-size:10;fill:${rect.color};fill-rule:evenodd;stroke:#000000;stroke-width:0.4;" />
     ${endfor}
   </g>
 ${endfor}
@@ -108,8 +122,13 @@ ${endfor}
 
 ${if project.tooltip}
   <g transform="translate(0,0)" visibility="hidden" id="tooltip">
-       <rect id="tooltiprect" y="-15" x="-3" width="1" height="20" style="stroke:black;fill:#edefc2;stroke-width:1"/>
-       <text id="tooltiptext" style="font-family:Arial; font-size:12;fill:black;"> </text>
+       <rect id="tooltiprect" y="-15" x="-3" width="1" height="72" style="stroke:black;fill:#edefc2;stroke-width:1"/>
+       <text id="tooltiptext" style="font-family:Arial; font-size:12;fill:black;">
+         <tspan id="tooltipcls" x="0" dy="0"> </tspan>
+         <tspan id="tooltipstr" x="0" dy="16"> </tspan>
+         <tspan id="tooltiptime" x="0" dy="16"> </tspan>
+         <tspan id="tooltipoutputs" x="0" dy="16"> </tspan>
+       </text>
   </g>
 ${endif}
 
@@ -285,7 +304,7 @@ def set_running(self, by, tsk):
 			i = cache[tsk]
 			del cache[tsk]
 
-		self.taskinfo.put( (i, id(tsk), time.time(), tsk.__class__.__name__, self.processed, self.count, by, str(tsk))  )
+		self.taskinfo.put( (i, id(tsk), time.time(), tsk.__class__.__name__, self.processed, self.count, by, ",".join(map(str, tsk.outputs)), str(tsk))  )
 Runner.Parallel.set_running = set_running
 
 def name2class(name):
@@ -366,7 +385,7 @@ def make_picture(producer):
 				end = line[2]
 				#print id, thread_id, begin, end
 				#acc.append(  ( 10*thread_id, 10*(thread_id+1), 10*begin, 10*end ) )
-				acc.append( (BAND * begin, BAND*thread_id, BAND*end - BAND*begin, BAND, line[3], line[7]) )
+				acc.append( (BAND * begin, BAND*thread_id, BAND*end - BAND*begin, BAND, line[3], line[7], line[8], end - begin) )
 				break
 
 	if Options.options.dmaxtime < 0.1:
@@ -400,11 +419,11 @@ def make_picture(producer):
 	model.title_y = gheight + - 5
 
 	groups = {}
-	for (x, y, w, h, clsname, name) in acc:
+	for (x, y, w, h, clsname, outputs, taskstr, time) in acc:
 		try:
-			groups[clsname].append((x, y, w, h, name))
+			groups[clsname].append((x, y, w, h, outputs, taskstr, time))
 		except:
-			groups[clsname] = [(x, y, w, h, name)]
+			groups[clsname] = [(x, y, w, h, outputs, taskstr, time)]
 
 	# groups of rectangles (else js highlighting is slow)
 	model.groups = []
@@ -413,14 +432,16 @@ def make_picture(producer):
 		model.groups.append(g)
 		g.classname = name2class(cls)
 		g.rects = []
-		for (x, y, w, h, name) in groups[cls]:
+		for (x, y, w, h, name, taskstr, time) in groups[cls]:
 			r = tobject()
 			g.rects.append(r)
 			r.x = 2 + x * ratio
 			r.y = 2 + y
 			r.width = w * ratio
 			r.height = h
-			r.name = name
+			r.outputs = outputs
+			r.taskstr = taskstr
+			r.time = '{:0.3f}'.format(time)
 			r.color = map_to_color(cls)
 
 	cnt = THREAD_AMOUNT

--- a/waflib/extras/parallel_debug.py
+++ b/waflib/extras/parallel_debug.py
@@ -432,7 +432,7 @@ def make_picture(producer):
 		model.groups.append(g)
 		g.classname = name2class(cls)
 		g.rects = []
-		for (x, y, w, h, name, taskstr, time) in groups[cls]:
+		for (x, y, w, h, outputs, taskstr, time) in groups[cls]:
 			r = tobject()
 			g.rects.append(r)
 			r.x = 2 + x * ratio

--- a/waflib/extras/parallel_debug.py
+++ b/waflib/extras/parallel_debug.py
@@ -346,7 +346,7 @@ def make_picture(producer):
 		thread_count += x[6]
 		acc.append("%d %d %f %r %d %d %d %s" % (x[0], x[1], x[2] - ini, x[3], x[4], x[5], thread_count, x[7]))
 
-	data_node = producer.bld.path.make_node('pdebug.dat')
+	data_node = producer.bld.path.make_node('pdebug-{}.dat'.format(producer.bld.cmd))
 	data_node.write('\n'.join(acc))
 
 	tmp = [lst[:2] + [float(lst[2]) - ini] + lst[3:] for lst in tmp]
@@ -468,7 +468,7 @@ def make_picture(producer):
 	template1 = compile_template(SVG_TEMPLATE)
 	txt = template1(model)
 
-	node = producer.bld.path.make_node('pdebug.svg')
+	node = producer.bld.path.make_node('pdebug-{}.svg'.format(producer.bld.cmd))
 	node.write(txt)
 	Logs.warn('Created the diagram %r', node)
 

--- a/waflib/extras/swig.py
+++ b/waflib/extras/swig.py
@@ -20,7 +20,7 @@ SWIG_EXTS = ['.swig', '.i']
 re_module = re.compile(r'%module(?:\s*\(.*\))?\s+([^\r\n]+)', re.M)
 
 re_1 = re.compile(r'^%module.*?\s+([\w]+)\s*?$', re.M)
-re_2 = re.compile(r'[#%](?:include|import(?:\(module=".*"\))+|python(?:begin|code)) [<"](.*)[">]', re.M)
+re_2 = re.compile(r'[#%](?:include|import(?:\(module=".*"\))+|python(?:begin|code)) [<"]?([\w\/\\.]+)[">]?', re.M)
 
 class swig(Task.Task):
 	color   = 'BLUE'
@@ -82,7 +82,7 @@ class swig(Task.Task):
 			# find .i files and project headers
 			names = re_2.findall(code)
 			for n in names:
-				for d in self.generator.includes_nodes + [node.parent]:
+				for d in c_preproc.get_header_nodepaths(self.generator.includes_nodes+[node.parent]):
 					u = d.find_resource(n)
 					if u:
 						to_see.append(u)

--- a/wscript
+++ b/wscript
@@ -106,8 +106,8 @@ def options(opt):
 		dest='strip_comments')
 	opt.add_option('--nostrip', action='store_false', help='no shrinking',
 		dest='strip_comments')
-	opt.add_option('--tools', action='store', help='Comma-separated 3rd party tools to add, eg: "compat,ocaml" [Default: "compat15"]',
-		dest='add3rdparty', default='compat15')
+	opt.add_option('--tools', action='store', help='Comma-separated 3rd party tools to add, eg: "compat,ocaml" [Default: all of them]',
+		dest='add3rdparty', default='')
 	opt.add_option('--coretools', action='store', help='Comma-separated core tools to add, eg: "vala,tex" [Default: all of them]',
 		dest='coretools', default='default')
 	opt.add_option('--prelude', action='store', help='Code to execute before calling waf', dest='prelude', default=PRELUDE)
@@ -250,7 +250,7 @@ def create_waf(self, *k, **kw):
 
 		elif os.path.isabs(x):
 			files.append(x)
-		else:
+		elif x:
 			add3rdparty.append(x + '.py')
 
 	coretools = []
@@ -267,7 +267,7 @@ def create_waf(self, *k, **kw):
 			if node.name not in coretools:
 				continue
 		if node.parent.name == 'extras':
-			if node.name not in add3rdparty:
+			if add3rdparty and node.name not in add3rdparty:
 				continue
 		files.append(relpath)
 


### PR DESCRIPTION
BLDMGR-10051
Rebased our patches onto the upstream waf repo from: https://gitlab.com/ita1024/waf

One commit for `qt5` tool was dropped since Qt6 is now supported with the waf `qt5` tool.
It just needs to be configured before the tool is loaded with `conf.want_qt6 = True`.

I had to add the upstream waf-2.1.6 branch to the repo as well so that the pull request has the proper base branch to compare against.