### PR TITLE
  SHARED-11649: investigate github windows build performance

### DIFF
--- a/waflib/Tools/c_preproc.py
+++ b/waflib/Tools/c_preproc.py
@@ -1093,7 +1093,17 @@ def get_header_nodepaths(includes):
 	# bld nodes may be subdirs thereof. The best example is
 	# $SCHRODINGER/$MMSHARE/include directory, and a build node might be
 	# $SCHRODINGER/$MMSHARE/canvaslibs
+	#
+	# NOTE: After enabling Package Factory builds, all thirdparty libs will be
+	# located in the $SCHRODINGER directory, so we should explicitly exclude them
+
 	schrodinger = os.path.abspath(os.environ['SCHRODINGER'])
 	schrodinger_src = os.path.abspath(os.environ['SCHRODINGER_SRC'])
-	nodepaths=[x for x in includes if os.path.abspath(x.abspath()).startswith(schrodinger) or os.path.abspath(x.abspath()).startswith(schrodinger_src)]
+	schrodinger_lib = os.path.abspath(os.environ['SCHRODINGER_LIB']) # PF directory
+
+	def _is_selected_inc_path(inc_path):
+		inc_path = os.path.abspath(x.abspath())
+		return (inc_path.startswith(schrodinger) or inc_path.startswith(schrodinger_src)) and not inc_path.startswith(schrodinger_lib)
+
+	nodepaths=[x for x in includes if _is_selected_inc_path(x)]
 	return nodepaths

--- a/waflib/Tools/c_preproc.py
+++ b/waflib/Tools/c_preproc.py
@@ -1102,7 +1102,7 @@ def get_header_nodepaths(includes):
 	schrodinger_lib = os.path.abspath(os.environ['SCHRODINGER_LIB']) # PF directory
 
 	def _is_selected_inc_path(inc_path):
-		inc_path = os.path.abspath(x.abspath())
+		inc_path = os.path.abspath(inc_path.abspath())
 		return (inc_path.startswith(schrodinger) or inc_path.startswith(schrodinger_src)) and not inc_path.startswith(schrodinger_lib)
 
 	nodepaths=[x for x in includes if _is_selected_inc_path(x)]

--- a/waflib/Tools/c_preproc.py
+++ b/waflib/Tools/c_preproc.py
@@ -1103,7 +1103,7 @@ def get_header_nodepaths(includes):
 
 	def _is_selected_inc_path(inc_path):
 		inc_path = os.path.abspath(inc_path.abspath())
-		return (inc_path.startswith(schrodinger) or inc_path.startswith(schrodinger_src)) and not inc_path.startswith(schrodinger_lib)
+		return inc_path.startswith((schrodinger, schrodinger_src)) and not inc_path.startswith(schrodinger_lib)
 
 	nodepaths=[x for x in includes if _is_selected_inc_path(x)]
 	return nodepaths


### PR DESCRIPTION
When waf scans C/C++ source files to find dependencies via the included headers, we intentionally only track non-SOFTWARE_LIB schrodinger dependencies with the `get_header_nodepaths` api. This logic is currently broken for PF-enabled builds since package factory installs all third-party dependencies in the $SCHRODINGER build directory. This broken logic has significantly increased clean build times by up to 100%, so we should fix it.